### PR TITLE
Mount temp folder to output

### DIFF
--- a/stimela/cargo/cab/singularity_run
+++ b/stimela/cargo/cab/singularity_run
@@ -3,6 +3,7 @@ set -e
 set -u
 export INPUT=/scratch/input
 export OUTPUT=/scratch/output
+export TMPDIR=/scratch/output/tmp
 export CONFIG=/scratch/configfile
 export MSDIR=/scratch/msdir
 test -d $OUTPUT/.casa || { test -d /root/.casa && cp -r /root/.casa $OUTPUT/.casa; } || echo " "


### PR DESCRIPTION
This avoids crashes where /tmp is mounted on a root file system with limited capacity as the case with most server setups