### PR TITLE
With ragavi-vis included

### DIFF
--- a/stimela/cargo/base/ragavi/Dockerfile
+++ b/stimela/cargo/base/ragavi/Dockerfile
@@ -5,6 +5,6 @@ RUN docker-apt-install nodejs python3-pip
 RUN add-apt-repository ppa:git-core/ppa
 RUN apt-get update
 RUN apt-get install -y git
-RUN pip3 install git+git://github.com/ska-sa/xova.git@master
 RUN pip3 install -U pip setuptools
 RUN pip3 install ragavi
+RUN pip3 install git+git://github.com/ska-sa/xova.git@master

--- a/stimela/cargo/base/ragavi/Dockerfile
+++ b/stimela/cargo/base/ragavi/Dockerfile
@@ -2,5 +2,9 @@ FROM stimela/meqtrees:1.2.0
 RUN docker-apt-install curl
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN docker-apt-install nodejs python3-pip
+RUN add-apt-repository ppa:git-core/ppa
+RUN apt-get update
+RUN apt-get install -y git
+RUN pip3 install git+git://github.com/ska-sa/xova.git@master
 RUN pip3 install -U pip setuptools
 RUN pip3 install ragavi

--- a/stimela/cargo/cab/ragavi/Dockerfile
+++ b/stimela/cargo/cab/ragavi/Dockerfile
@@ -1,4 +1,4 @@
-FROM stimela/ragavi:dev
+FROM stimela/ragavi:1.2.6
 MAINTAINER <sphemakh@gmail.com>
 ADD src /scratch/code
 ENV LOGFILE ${OUTPUT}/logfile.txt

--- a/stimela/cargo/cab/ragavi/Dockerfile
+++ b/stimela/cargo/cab/ragavi/Dockerfile
@@ -1,4 +1,4 @@
-FROM stimela/ragavi:1.2.4
+FROM stimela/ragavi:1.2.6
 MAINTAINER <sphemakh@gmail.com>
 ADD src /scratch/code
 ENV LOGFILE ${OUTPUT}/logfile.txt

--- a/stimela/cargo/cab/ragavi/Dockerfile
+++ b/stimela/cargo/cab/ragavi/Dockerfile
@@ -1,4 +1,4 @@
-FROM stimela/ragavi:1.2.6
+FROM stimela/ragavi:dev
 MAINTAINER <sphemakh@gmail.com>
 ADD src /scratch/code
 ENV LOGFILE ${OUTPUT}/logfile.txt

--- a/stimela/cargo/cab/ragavi/parameters.json
+++ b/stimela/cargo/cab/ragavi/parameters.json
@@ -1,111 +1,112 @@
 {
     "task": "ragavi",
     "base": "stimela/ragavi",
-    "tag": "1.2.4",
+    "tag": "1.2.6",
     "description": "Radio Astronomy Gain and Visibility Inspector",
     "prefix": "--",
     "binary": "ragavi-gains",
     "msdir": false,
     "parameters": [
         {
-            "info": "Plot only this antenna, or comma-separated list of antennas. Default plots all",
-            "dtype": "str",
-            "required": false,
-            "name": "ant"
-        },
-        {
-            "info": "Correlation index to plot (Defaults to all)",
-            "dtype": "int",
-            "required": false,
-            "name": "corr"
-        },
-        {
-            "info": "Matplotlib colour map to use for antennas (default=coolwarm)",
-            "dtype": "str",
-            "default": "coolwarm",
-            "required": false,
-            "name": "cmap"
-        },
-        {
-            "info": "Plot complex values as amp and phase (ap) or real and imag (ri)",
-            "name": "doplot",
-            "default": "ap",
-            "dtype": "str",
-            "required": false,
-            "choices": [
-                "ap",
-                "ri"
-            ]
-        },
-        {
-            "info": "Field ID to plot",
-            "dtype": [
-                "list:str",
-                "list:int"
-            ],
-            "required": false,
-            "name": "field"
-        },
-        {
-            "info": "The gain type of table(s) to be plotted. Options: ['B', 'F', 'G', 'K']",
-            "dtype": "list:str",
-            "required": true,
-            "name": "gaintype"
-        },
-        {
-            "info": "Output html file name",
-            "dtype": "str",
-            "required": false,
-            "name": "htmlname",
-            "io": "output"
-        },
-        {
-            "info": "Output png/svg image file name",
-            "dtype": "str",
-            "required": false,
-            "name": "plotname",
-            "io": "output"
-        },
-        {
-            "info": "Gain table(s) to plot",
+            "info": "Gain table(s) to plot. Specify space separated list for multiple",
             "dtype": "list:file",
             "required": true,
             "name": "table",
             "io": "input"
         },
         {
-            "info": "Minimum time to plot (default = full range)",
-            "dtype": "float",
-            "required": false,
-            "name": "t0"
+            "info": "Type of gain table(s) to be plotted. Specify as a single character or space separated list for multiple tables.",
+            "dtype": "list:str",
+            "required": true,
+            "name": "gaintype",
+            "choices": [
+                "B",
+                "D"
+                "F", 
+                "G", 
+                "K"
+            ]
         },
         {
-            "info": "Maximum time to plot (default = full range)",
-            "dtype": "float",
+            "info": "Plot only a specific antenna, or comma-separated list of antennas. Defaults to all",
+            "dtype": "str",
             "required": false,
-            "name": "t1"
+            "name": "ant"
         },
         {
-            "info": "SPECTRAL_WINDOW_ID or ddid number. Defaults to all",
-            "dtype": "float",
+            "info": "Correlation index (ices) to plot. Defaults to all.",
+            "dtype": "str",
+            "required": false,
+            "name": "corr"
+        },
+        {
+            "info": "Matplotlib colour map to use for antennas. Defaults to coolwarm",
+            "dtype": "str",
+            "default": "coolwarm",
+            "required": false,
+            "name": "cmap"
+        },
+        {
+            "info": "Spectral window to plot. Defaults to all",
+            "dtype": "str",
             "required": false,
             "name": "ddid"
         },
         {
-            "info": "TAQL where clause",
+            "info": "Plot amplitude & phase (ap) or real and imaginary (ri). Defaults to ap.",
+            "name": "doplot",
             "dtype": "str",
             "required": false,
-            "name": "taql"
+            "default": "ap",
+            "choices": [
+                "ap",
+                "ri"
+            ]
         },
         {
-            "info": "Chose the x-xaxis for the K table.",
+            "info": "Field ID(s) / NAME(s) to plot. Defaults to all",
+            "dtype": [
+                "list:str"
+            ],
+            "required": false,
+            "name": "field"
+        },
+        {
+            "info": "Output HTML file name",
+            "dtype": "str",
+            "required": false,
+            "name": "htmlname",
+            "io": "output"
+        },
+        {
+            "info": "Choose the x-xaxis for the K table.",
             "dtype": "str",
             "required": false,
             "name": "k-xaxis",
             "choices": [
                 "time",
                 "antenna"
-            ]
+            ],
+            "default": "time"
+        },
+        {
+            "info": "Min time to plot [in seconds]. Defaults to full range]",
+            "dtype": "float",
+            "required": false,
+            "name": "t0"
+        },
+        {
+            "info": "Max time to plot [in seconds]. Defaults to full range",
+            "dtype": "float",
+            "required": false,
+            "name": "t1"
+        },
+        {
+            "info": "TAQL where clause",
+            "dtype": "str",
+            "required": false,
+            "name": "taql"
         }
+        
     ]
 }

--- a/stimela/cargo/cab/ragavi/parameters.json
+++ b/stimela/cargo/cab/ragavi/parameters.json
@@ -21,7 +21,7 @@
             "name": "gaintype",
             "choices": [
                 "B",
-                "D"
+                "D",
                 "F", 
                 "G", 
                 "K"

--- a/stimela/cargo/cab/ragavi/parameters.json
+++ b/stimela/cargo/cab/ragavi/parameters.json
@@ -1,7 +1,7 @@
 {
     "task": "ragavi",
     "base": "stimela/ragavi",
-    "tag": "1.2.6",
+    "tag": "dev",
     "description": "Radio Astronomy Gain and Visibility Inspector",
     "prefix": "--",
     "binary": "ragavi-gains",

--- a/stimela/cargo/cab/ragavi/parameters.json
+++ b/stimela/cargo/cab/ragavi/parameters.json
@@ -1,7 +1,7 @@
 {
     "task": "ragavi",
     "base": "stimela/ragavi",
-    "tag": "dev",
+    "tag": "1.2.6",
     "description": "Radio Astronomy Gain and Visibility Inspector",
     "prefix": "--",
     "binary": "ragavi-gains",

--- a/stimela/cargo/cab/ragavi_vis/Dockerfile
+++ b/stimela/cargo/cab/ragavi_vis/Dockerfile
@@ -1,0 +1,5 @@
+FROM stimela/ragavi:1.2.6
+MAINTAINER <sphemakh@gmail.com>
+ADD src /scratch/code
+ENV LOGFILE ${OUTPUT}/logfile.txt
+CMD /scratch/code/run.sh

--- a/stimela/cargo/cab/ragavi_vis/Dockerfile
+++ b/stimela/cargo/cab/ragavi_vis/Dockerfile
@@ -1,4 +1,4 @@
-FROM stimela/ragavi:dev
+FROM stimela/ragavi:1.2.6
 MAINTAINER <sphemakh@gmail.com>
 ADD src /scratch/code
 ENV LOGFILE ${OUTPUT}/logfile.txt

--- a/stimela/cargo/cab/ragavi_vis/Dockerfile
+++ b/stimela/cargo/cab/ragavi_vis/Dockerfile
@@ -1,4 +1,4 @@
-FROM stimela/ragavi:1.2.6
+FROM stimela/ragavi:dev
 MAINTAINER <sphemakh@gmail.com>
 ADD src /scratch/code
 ENV LOGFILE ${OUTPUT}/logfile.txt

--- a/stimela/cargo/cab/ragavi_vis/parameters.json
+++ b/stimela/cargo/cab/ragavi_vis/parameters.json
@@ -34,12 +34,12 @@
                 "scan", 
                 "time",
                 "uvdist",
-                "uvwave",
+                "uvwave"
                 ]
         },
         {
             "info": "Y-axis to plot.",
-            "dtype": " ",
+            "dtype": "str",
             "required": true,
             "name": "yaxis",
             "default": null,
@@ -47,7 +47,7 @@
                 "amplitude", 
                 "imaginary", 
                 "phase",
-                "real", 
+                "real"
                 ]
         },
         {
@@ -105,7 +105,7 @@
                 "corr", 
                 "field", 
                 "scan", 
-                "spw",
+                "spw"
                 ]
         },
         {
@@ -113,7 +113,7 @@
             "dtype": "str",
             "required": false,
             "name": "corr",
-            "default": "0:",
+            "default": "0:"
         },
         {
             "info": "MS column to use for data.",
@@ -157,7 +157,7 @@
                 "corr", 
                 "field", 
                 "scan", 
-                "spw",
+                "spw"
                 ]
         },
         {
@@ -229,6 +229,5 @@
             "name": "ymax",
             "default": null
         }
-        
     ]
 }

--- a/stimela/cargo/cab/ragavi_vis/parameters.json
+++ b/stimela/cargo/cab/ragavi_vis/parameters.json
@@ -1,11 +1,11 @@
 {
     "task": "ragavi",
-    "base": "stimela/ragavi_vis",
-    "tag": "1.2.6",
+    "base": "stimela/ragavi",
+    "tag": "dev",
     "description": "Radio Astronomy Gain and Visibility Inspector",
     "prefix": "--",
     "binary": "ragavi-vis",
-    "msdir": false,
+    "msdir": true,
     "parameters": [
         {
             "info": "MS to plot.",
@@ -171,8 +171,7 @@
             "info": "Plot only unflagged data. Defaults to true.",
             "dtype": "bool",
             "required": false,
-            "name": "no-flagged",
-            "default": true
+            "name": "no-flagged"
         },
         {
             "info": "Number of CPU cores to be used by Dask. Defaults to half the CPU cores available.",

--- a/stimela/cargo/cab/ragavi_vis/parameters.json
+++ b/stimela/cargo/cab/ragavi_vis/parameters.json
@@ -1,0 +1,234 @@
+{
+    "task": "ragavi",
+    "base": "stimela/ragavi_vis",
+    "tag": "1.2.6",
+    "description": "Radio Astronomy Gain and Visibility Inspector",
+    "prefix": "--",
+    "binary": "ragavi-vis",
+    "msdir": false,
+    "parameters": [
+        {
+            "info": "MS to plot.",
+            "dtype": "list:file",
+            "required": true,
+            "name": "ms",
+            "default": null,
+            "io": "input"
+        },
+        {
+            "info": "X-axis to plot.",
+            "dtype": "str",
+            "required": true,
+            "name": "xaxis",
+            "default": null,
+            "choices": [
+                "antenna1", 
+                "antenna2", 
+                "baseline",
+                "channel",
+                "corr", 
+                "field", 
+                "frequency",
+                "phase",
+                "real",
+                "scan", 
+                "time",
+                "uvdist",
+                "uvwave",
+                ]
+        },
+        {
+            "info": "Y-axis to plot.",
+            "dtype": " ",
+            "required": true,
+            "name": "yaxis",
+            "default": null,
+            "choices": [
+                "amplitude", 
+                "imaginary", 
+                "phase",
+                "real", 
+                ]
+        },
+        {
+            "info": "Set height of the resulting image.",
+            "dtype": "int",
+            "required": false,
+            "name": "canvas-height",
+            "default": 1020
+        },
+        {
+            "info": "Set width of the resulting image.",
+            "dtype": "int",
+            "required": false,
+            "name": "canvas-width",
+            "default": 1280
+        },
+        {
+            "info": "Size of channel bins over which to average.",
+            "dtype": "int",
+            "required": false,
+            "name": "cbin",
+            "default": null
+        },
+        {
+            "info": "Channels to select. Defaults to all.",
+            "dtype": "str",
+            "required": false,
+            "name": "chan",
+            "default": null
+        },
+        {
+            "info": "Chunk sizes to be applied to the dataset. Defaults to 100,000 in the row axis.",
+            "dtype": "str",
+            "required": false,
+            "name": "chunks",
+            "default": null
+        },
+        {
+            "info": "Colour or colour map to use.",
+            "dtype": "str",
+            "required": false,
+            "name": "cmap",
+            "default": "blues"
+        },
+        {
+            "info": "Select column to colourise by.",
+            "dtype": "str",
+            "required": false,
+            "name": "colour-axis",
+            "default": null,
+            "choices": [
+                "antenna1", 
+                "antenna2", 
+                "baseline",
+                "corr", 
+                "field", 
+                "scan", 
+                "spw",
+                ]
+        },
+        {
+            "info": "Correlation index or subset to plot. Can be specified using normal python slicing syntax. Defaults to all.",
+            "dtype": "str",
+            "required": false,
+            "name": "corr",
+            "default": "0:",
+        },
+        {
+            "info": "MS column to use for data.",
+            "dtype": "str",
+            "required": false,
+            "name": "data-column",
+            "default": "DATA"
+        },
+        {
+            "info": "DATA_DESC_ID(s) /spw to select. Can be specified as e.g. 5, 5,6,7, 5~7 (inclusive range), 5:8 (exclusive range), 5:(from 5 to last). Defaults to all",
+            "dtype": "str",
+            "required": false,
+            "name": "ddid",
+            "default": null
+        },
+        {
+            "info": "Field ID(s) / NAME(s) to plot. Can be specified as '0', '0,2,4', '0~3' (inclusive range), '0:3' (exclusive range), '3:' (from 3 to last) or using a field name or comma separated field names. Defaults to all.",
+            "dtype": "str",
+            "required": false,
+            "name": "field",
+            "default": null
+        },
+        {
+            "info": "Output HTML file name",
+            "dtype": "str",
+            "required": false,
+            "name": "htmlname",
+            "default": null,
+            "io": "output"
+        },
+        {
+            "info": "Select column to iterate by.",
+            "dtype": "str",
+            "required": false,
+            "name": "iter-axis",
+            "default": null,
+            "choices": [
+                "antenna1", 
+                "antenna2", 
+                "baseline",
+                "corr", 
+                "field", 
+                "scan", 
+                "spw",
+                ]
+        },
+        {
+            "info": "Memory limit per core.",
+            "dtype": "str",
+            "required": false,
+            "name": "mem-limit",
+            "default": "1GB"
+        },
+        {
+            "info": "Plot only unflagged data. Defaults to true.",
+            "dtype": "bool",
+            "required": false,
+            "name": "no-flagged",
+            "default": true
+        },
+        {
+            "info": "Number of CPU cores to be used by Dask. Defaults to half the CPU cores available.",
+            "dtype": "int",
+            "required": false,
+            "name": "num-cores"
+        },
+        {
+            "info": "Scan Number to select. Defaults to all.",
+            "dtype": "str",
+            "required": false,
+            "name": "scan",
+            "default": null
+        },
+        {
+            "info": "TAQL where clause",
+            "dtype": "str",
+            "required": false,
+            "name": "taql",
+            "default": null
+        },
+        {
+            "info": "Time in seconds over which to average.",
+            "dtype": "float",
+            "required": false,
+            "name": "tbin",
+            "default": null
+        },
+        {
+            "info": "Minimum x value to plot",
+            "dtype": "float",
+            "required": false,
+            "name": "xmin",
+            "default": null
+        },
+        {
+            "info": "Maximum x value to plot",
+            "dtype": "float",
+            "required": false,
+            "name": "xmax",
+            "default": null
+        },
+        {
+            "info": "Minimum y value to plot",
+            "dtype": "float",
+            "required": false,
+            "name": "ymin",
+            "default": null
+        },
+        {
+            "info": "Maximum y value to plot",
+            "dtype": "float",
+            "required": false,
+            "name": "ymax",
+            "default": null
+        }
+        
+    ]
+}

--- a/stimela/cargo/cab/ragavi_vis/parameters.json
+++ b/stimela/cargo/cab/ragavi_vis/parameters.json
@@ -1,7 +1,7 @@
 {
     "task": "ragavi",
     "base": "stimela/ragavi",
-    "tag": "dev",
+    "tag": "1.2.6",
     "description": "Radio Astronomy Gain and Visibility Inspector",
     "prefix": "--",
     "binary": "ragavi-vis",

--- a/stimela/cargo/cab/ragavi_vis/src/run.py
+++ b/stimela/cargo/cab/ragavi_vis/src/run.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.append('/scratch/stimela')
+
+utils = __import__('utils')
+
+CONFIG = os.environ["CONFIG"]
+INPUT = os.environ["INPUT"]
+MSDIR = os.environ["MSDIR"]
+
+cab = utils.readJson(CONFIG)
+args = []
+
+for param in cab['parameters']:
+    name = param['name']
+    value = param['value']
+    if value is None:
+        continue
+    elif value is False:
+        continue
+
+    if isinstance(value, list):
+        val = map(str, value)
+        args += ['{0}{1} {2}'.format(cab['prefix'], name, " ".join(val))]
+        continue
+
+    args += ['{0}{1} {2}'.format(cab['prefix'], name, value)]
+
+utils.xrun(cab['binary'], args)

--- a/stimela/cargo/cab/ragavi_vis/src/run.sh
+++ b/stimela/cargo/cab/ragavi_vis/src/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+python /scratch/code/run.py 2>&1 | tee -a $LOGFILE 
+(exit ${PIPESTATUS[0]})


### PR DESCRIPTION
- Added cab for `ragavi-vis` under the name: ragavi_vis
- Changed docker file to download `xova` from github
- Updated some `ragavi-gains` params
- Tested locally 

The new Docker image is at: [my docker repo](https://hub.docker.com/r/mulan94/ragavi) because I don't have access to `stimela/ragavi`