### PR TITLE
Add override for printing only to stdout

### DIFF
--- a/Jenkinsfile.sh
+++ b/Jenkinsfile.sh
@@ -53,4 +53,6 @@ stimela build -nc
 
 #Run forest run!
 cd $TEST_OUTPUT_DIR
+export SILENT_STDERR=ON
 python3 -m nose --with-xunit --xunit-file $WORKSPACE_ROOT/nosetests.xml "${WORKSPACE_ROOT}/projects/Stimela/stimela/tests"
+

--- a/stimela/__init__.py
+++ b/stimela/__init__.py
@@ -4,6 +4,7 @@ import sys
 import inspect
 import pkg_resources
 import logging
+from logging import StreamHandler
 import re
 from pathlib import Path
 
@@ -92,7 +93,10 @@ def logger(name="STIMELA", propagate=False, console=True, boring=False,
         log_formatter = log_boring_formatter if boring else log_colourful_formatter
 
         if console:
-            log_console_handler = MultiplexingHandler()
+            if "SILENT_STDERR" in os.environ and os.environ["SILENT_STDERR"].upper()=="ON":
+                log_console_handler = StreamHandler(stream=sys.stdout)
+            else:  
+                log_console_handler = MultiplexingHandler()
             log_console_handler.setFormatter(log_formatter)
             log_console_handler.setLevel(logging.INFO)
             _logger.addHandler(log_console_handler)

--- a/stimela/cargo/cab/casa_bandpass/src/run.py
+++ b/stimela/cargo/cab/casa_bandpass/src/run.py
@@ -50,4 +50,4 @@ except ValueError:
     ids = map(lambda a: field_names.index(a), field_in)
 
 if not set(ids).issubset(field_ids):
-    raise Runtime("Some field(s) do have solutions after the calibration. Please refer to CASA {task} logfile for further details".format(cab["prefix"]))
+    raise RuntimeError("Some field(s) do have solutions after the calibration. Please refer to CASA {task} logfile for further details".format(cab["prefix"]))

--- a/stimela/cargo/cab/casa_gaincal/src/run.py
+++ b/stimela/cargo/cab/casa_gaincal/src/run.py
@@ -49,4 +49,4 @@ except ValueError:
     ids = map(lambda a: field_names.index(a), field_in)
 
 if not set(ids).issubset(field_ids):
-    raise Runtime("Some field(s) do have solutions after the calibration. Please refer to CASA {task} logfile for further details".format(cab["prefix"]))
+    raise RuntimeError("Some field(s) do have solutions after the calibration. Please refer to CASA {task} logfile for further details".format(cab["prefix"]))

--- a/stimela/utils/xrun_poll.py
+++ b/stimela/utils/xrun_poll.py
@@ -61,7 +61,7 @@ class Poller(object):
                     if verbose:
                         self.log.debug("poll(): retrying")
                 else:
-                    raise
+                    raise ioerr
 
     def unregister_file(self, fobj):
         if fobj.fileno() in self.fdlabels:


### PR DESCRIPTION
Override new behavior of printing to both stdout and stderr in the logger so that testing logs can be clean