### PR TITLE
Changed version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = ["pyyaml",
                 ],
 
 PACKAGE_NAME = "stimela"
-__version__ = "1.4.6"
+__version__ = "1.5.0"
 
 setup(name=PACKAGE_NAME,
       version=__version__,


### PR DESCRIPTION
Changing only __version__ = "1.5.0" in setup.py
Stimela 1.5.0 is not in pypi, which is why caracal hangs