### PR TITLE
cubical 1.5.8 release

### DIFF
--- a/stimela/cargo/base/cubical/Dockerfile
+++ b/stimela/cargo/base/cubical/Dockerfile
@@ -5,5 +5,5 @@ RUN docker-apt-install casacore-dev \
     libboost-all-dev \
     wcslib-dev \
     libcfitsio-dev
-RUN pip install "cubical[lsm-support]@git+https://github.com/ratt-ru/CubiCal.git@v1.5.5" scabha
+RUN pip install "cubical[lsm-support]@git+https://github.com/ratt-ru/CubiCal.git@v1.5.8" scabha
 RUN gocubical --help

--- a/stimela/cargo/cab/cubical/parameters.json
+++ b/stimela/cargo/cab/cubical/parameters.json
@@ -1,10 +1,10 @@
 {
     "task": "cubical", 
     "base": "stimela/cubical", 
-    "tag": "1.6.7", 
+    "tag": "1.5.8", 
     "description": "CubiCal is a suite of fast radio interferometric calibration routines exploiting complex optimisation.", 
     "prefix": "--",
-    "version":"1.5.5",
+    "version":"1.5.8",
     "binary": "gocubical",
     "junk":["cubical.last", "montblanc.log"],
     "msdir": true, 


### PR DESCRIPTION
The previous cubical base image was tagged 1.6.7. I'm sorry, I tried to make an image tagged 1.6.8 containing CubiCal release 1.5.8, but a little OCD homunculus inside me woke up, stomped its feet and shouted, "No more! Cannot take! Consistent versions matter!"

So I gave in, and tagged the new image 1.5.8. If there's a secret user community out there using vintage 1.5.8 images (containing CubiCal release 1.3.6, no doubt...), they've just been royally and callously screwed. Sorrynotsorry.

Seriously though, may I suggest we slowly gravitate to a situation where Stimela image tags follow the underlying package version (at least for "single malt" cabs such as e.g. cubical and wsclean)? This may mean revising some tags "down", as is the case here, but that's ok, right?



