### PR TITLE
Sunblocker

### DIFF
--- a/stimela/cargo/base/sunblocker/Dockerfile
+++ b/stimela/cargo/base/sunblocker/Dockerfile
@@ -1,4 +1,4 @@
-FROM stimela/base:1.2.0
+FROM stimela/base:1.6.0
 MAINTAINER <sphemakh@gmail.com>
 RUN docker-apt-install python-casacore python-tk python-pip git
 RUN pip install --upgrade git+https://github.com/gigjozsa/sunblocker

--- a/stimela/cargo/base/sunblocker/Dockerfile
+++ b/stimela/cargo/base/sunblocker/Dockerfile
@@ -1,4 +1,9 @@
 FROM stimela/base:1.6.0
-MAINTAINER <sphemakh@gmail.com>
-RUN docker-apt-install python-casacore python-tk python-pip git
-RUN pip install --upgrade git+https://github.com/gigjozsa/sunblocker
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 10
+RUN apt-get update
+RUN apt-get -y install xvfb
+RUN pip3 install -U pip setuptools \
+    pyyaml
+RUN pip install scabha
+RUN pip install -I sunblocker==1.0.1

--- a/stimela/cargo/cab/sunblocker/parameters.json
+++ b/stimela/cargo/cab/sunblocker/parameters.json
@@ -1,8 +1,8 @@
 {
     "task": "sunblocker", 
     "base": "stimela/sunblocker", 
-    "tag": "1.2.0", 
-    "version" : "1.0.0",
+    "tag": "1.2.1", 
+    "version" : "1.0.1",
     "description": "Tools for manipulating measurement sets (MSs)", 
     "prefix": " ", 
     "binary": "msutils",
@@ -83,7 +83,7 @@
             "name": "pol"
         }, 
         {
-            "info": "Method to determine sigma, 'fit': fit Gaussian at the max to determine sigma, standard deviation otherwise", 
+            "info": "Method to determine sigma, 'fit': fit Gaussian at the max to determine sigma, 'mad': use median and standard deviation as derived using MAD statistics, standard deviation otherwise", 
             "dtype": "str", 
             "default": null, 
             "name": "threshmode"
@@ -107,10 +107,16 @@
             "name": "angle"
         }, 
         {
-            "info": "Apply phazer only on daytime data as selected using vampirisms", 
+            "info": "Analyse data in phazer only using daytime data as selected using vampirisms", 
             "dtype": "bool", 
             "default": false, 
             "name": "vampirisms"
+        }, 
+        {
+            "info": "Flag only daytime data as identified by using vampirisms", 
+            "dtype": "bool", 
+            "default": false, 
+            "name": "flagonlyday"
         }, 
         {
             "info": "Show histogram and cutoff line in a viewgraph", 

--- a/stimela/cargo/cab/sunblocker/parameters.json
+++ b/stimela/cargo/cab/sunblocker/parameters.json
@@ -1,7 +1,7 @@
 {
     "task": "sunblocker", 
     "base": "stimela/sunblocker", 
-    "tag": "1.2.1", 
+    "tag": "1.0.2", 
     "version" : "1.0.1",
     "description": "Tools for manipulating measurement sets (MSs)", 
     "prefix": " ", 
@@ -32,7 +32,7 @@
             "dtype": "file", 
             "required": false, 
             "name": "outset", 
-            "io": "msfile"
+            "io": "output"
         }, 
         {
             "info": "Column name", 


### PR DESCRIPTION
Updating sunblocker:
- some bugfixes/feature changes (not really bugs bar one)
- Python 3
- Introducing parameter flagonlyday
Image has been uploaded and this code has been tested. Example, assuming the files ``before_1.ms`` and ``before_1.ms`` in directory ``dummy``:
```
#! /usr/bin/env python
import stimela

INPUT = 'input'
OUTPUT = 'dummy'
PREFIX = 'stimela-sunblocker-example'

recipe = stimela.Recipe("Stimela sunblocker example", ms_dir='dummy')

params = {
    'command': 'phazer',
    'inset': ['before_1.ms','before_2.ms'],
    'outset': ['sunblock_1.ms','sunblock_2.ms'],
    'imsize': 128,
    'cell': 32,
    'pol': 'i',
    'threshold':5.,
    'mode':'all',
    'radrange': 0,
    'angle': 0,
    'show': 'test.pdf',
    'verb': True,
    'dryrun': False,
    'uvmax': 3000,
    'vampirisms': False,
    'flagonlyday': True,
    'threshmode':'mad'
}
 
recipe.add('cab/sunblocker',
           'sunblocker_test',
           params,
           input=INPUT,
           output=OUTPUT,
           label='Test sunblocker'
)
 
recipe.run()
```