### PR TITLE
Configuratt logging update

### DIFF
--- a/stimela/__init__.py
+++ b/stimela/__init__.py
@@ -1,12 +1,12 @@
 # -*- coding: future_fstrings -*-
-import os
-import sys
+import os, sys, re
 import inspect
 import pkg_resources
 import logging
 from logging import StreamHandler
-import re
+from typing import Union, Optional
 from pathlib import Path
+from omegaconf import OmegaConf
 
 try:
     __version__ = pkg_resources.require("stimela")[0].version
@@ -59,60 +59,7 @@ for item in os.listdir(CAB_PATH):
             CAB.append(item)
 
 
-_logger = None
-
-from .utils.logger import SelectiveFormatter, ColorizingFormatter, ConsoleColors, MultiplexingHandler
-
-log_console_handler = log_formatter = log_boring_formatter = log_colourful_formatter = None
-
-def is_logger_initialized():
-    return _logger is not None
-
-def logger(name="STIMELA", propagate=False, console=True, boring=False,
-           fmt="{asctime} {name} {levelname}: {message}",
-           col_fmt="{asctime} {name} %s{levelname}: {message}%s"%(ConsoleColors.BEGIN, ConsoleColors.END),
-           sub_fmt="# {message}",
-           col_sub_fmt="%s# {message}%s"%(ConsoleColors.BEGIN, ConsoleColors.END),
-           datefmt="%Y-%m-%d %H:%M:%S", loglevel="INFO"):
-    """Returns the global Stimela logger (initializing if not already done so, with the given values)"""
-    global _logger
-    if _logger is None:
-        _logger = logging.getLogger(name)
-        if type(loglevel) is str:
-            loglevel = getattr(logging, loglevel)
-        _logger.setLevel(loglevel)
-        _logger.propagate = propagate
-
-        global log_console_handler, log_formatter, log_boring_formatter, log_colourful_formatter
-
-        # this function checks if the log record corresponds to stdout/stderr output from a cab
-        def _is_from_subprocess(rec):
-            return hasattr(rec, 'stimela_subprocess_output')
-
-        log_boring_formatter = SelectiveFormatter(
-                    logging.Formatter(fmt, datefmt, style="{"),
-                    [(_is_from_subprocess, logging.Formatter(sub_fmt, datefmt, style="{"))])
-
-        log_colourful_formatter = SelectiveFormatter(
-                    ColorizingFormatter(col_fmt, datefmt, style="{"),
-                    [(_is_from_subprocess, ColorizingFormatter(fmt=col_sub_fmt, datefmt=datefmt, style="{",
-                                                               default_color=ConsoleColors.DIM))])
-
-        log_formatter = log_boring_formatter if boring else log_colourful_formatter
-
-        if console:
-            if "SILENT_STDERR" in os.environ and os.environ["SILENT_STDERR"].upper()=="ON":
-                log_console_handler = StreamHandler(stream=sys.stdout)
-            else:  
-                log_console_handler = MultiplexingHandler()
-            log_console_handler.setFormatter(log_formatter)
-            log_console_handler.setLevel(loglevel)
-            _logger.addHandler(log_console_handler)
-
-        import scabha
-        scabha.set_logger(_logger)
-
-    return _logger
+from .stimelogging import logger
 
 from stimela.kitchen.recipe import Recipe
 

--- a/stimela/cargo/cabs/wsclean.yaml
+++ b/stimela/cargo/cabs/wsclean.yaml
@@ -85,41 +85,40 @@ inputs:
 outputs:
   msout:
     info: Output MS
-    dtype: Directory
+    dtype: MS
     implicit: "{self.ms}"
   dirty:
     info: Dirty images
-    dtype: File
-    implicit: "{self.prefix}*[0-9]-dity.fits"
+    dtype: List[File]
+    implicit: "{self.prefix}-????-dirty.fits"
   restored: 
     info: Restored images
-    dtype: File
-    implicit: "{self.prefix}*-[0-9]-image.fits"
+    dtype: List[File]
+    implicit: "{self.prefix}-????-image.fits"
   residual:
-    info: Residual images
-    dtype: File
-    implicit: "{self.prefix}*-[0-9]-residual.fits"
+    dtype: List[File]
+    implicit: "{self.prefix}-????-residual.fits"
   model:
     info: Model images
-    dtype: File
-    implicit: "{self.prefix}-*[0-9]-model.fits"
+    dtype: List[File]
+    implicit: "{self.prefix}-????-model.fits"
   restored_mfs:
     info: Restored MFS image
     dtype: File
-    implicit: "{self.prefix}-*-MFS-image.fits"
+    implicit: "{self.prefix}-MFS-image.fits"
   residual_mfs:
     info: Residual MFS image
     dtype: File
-    implicit: "{self.prefix}-*-MFS-residual.fits"
+    implicit: "{self.prefix}-MFS-residual.fits"
   model_mfs:
     info: Model MFS image
     dtype: File
-    implicit: "{self.prefix}-*-MFS-model.fits"
+    implicit: "{self.prefix}-MFS-model.fits"
   dirty_mfs:
     info: Dirty MFS image
     dtype: File
-    implicit: "{self.prefix}-*-MFS-dirty.fits"
+    implicit: "{self.prefix}-MFS-dirty.fits"
   source_list:
     info: Source list
     dtype: File
-    implicit: "{self.prefix}-*.txt"
+    implicit: "{self.prefix}-source-list.txt"

--- a/stimela/cargo/cabs/wsclean.yaml
+++ b/stimela/cargo/cabs/wsclean.yaml
@@ -5,10 +5,12 @@ info: Rapid Measurement Set plotting with xarray-ms and datashader.
 
 defaults:
   weight: "briggs 0."
+  column: DATA
 
 policies:
   positional: false
   prefix: "-"
+  replace: { '_': '-' }
 
 inputs:
   ms:
@@ -23,10 +25,13 @@ inputs:
     dtype: str
     alias: name
     required: true
-  channels-out:
+  column:
+    dtype: str
+    alias: data-column
+  nchan:
     info: Channels out
     dtype: int
-    alias: nchan
+    alias: channels-out
   j:
     info: Threads
     dtype: int
@@ -54,6 +59,28 @@ inputs:
   niter:
     info: Number of minor clean iterations
     dtype: int
+  auto_threshold:
+    dtype: float
+  auto_mask:
+    dtype: float
+  gain:
+    dtype: float
+  mgain:
+    dtype: float
+  join_channels:
+    dtype: bool
+  fit_spectral_pol:
+    dtype: int
+  fit_beam:
+    dtype: bool
+  elliptical_beam:
+    dtype: bool
+  padding:
+    dtype: float
+  nwlayers:
+    dtype: int
+  nwlayers_factor:
+    dtype: float
 
 outputs:
   msout:

--- a/stimela/commands/images.py
+++ b/stimela/commands/images.py
@@ -1,5 +1,6 @@
 import click
-from stimela.main import StimelaContext, cli, pass_stimela_context
+import stimela
+from stimela.main import cli
 
 
 @cli.command(
@@ -8,13 +9,13 @@ from stimela.main import StimelaContext, cli, pass_stimela_context
     short_help="list known stimela images")
 @click.option("-i", "--print-ids", is_flag=True, 
                 help="list in the more terse image+ID format.")
-@pass_stimela_context
-def images(context: StimelaContext, print_ids=False):
-
-    available = context.backend.available_images()
+def images(print_ids=False):
+    from stimela.main import BACKEND
+    log = stimela.logger()
+    available = BACKEND.available_images()
 
     if not print_ids:
-        context.log.info("image list follows")
+        log.info("image list follows")
 
         header = f"{'IMAGE':19} {'VERSION':19} {'DESCRIPTION':19} BUILT BY"
         print(header)

--- a/stimela/commands/push.py
+++ b/stimela/commands/push.py
@@ -1,7 +1,7 @@
 import click
 from typing import List
-from stimela.main import cli, StimelaContext, pass_stimela_context
-
+from stimela.main import cli
+import stimela
 
 @cli.command(
     help="""Push stimela base images. Specify a list of image names and versions (if a version is omitted, pushes all known versions of image),
@@ -12,11 +12,13 @@ from stimela.main import cli, StimelaContext, pass_stimela_context
 @click.argument("images", nargs=-1, metavar="NAME[:VERSION]", required=False) 
 @click.option("-a", "--all", is_flag=True, 
                 help="push all images")
-@pass_stimela_context
-def push(context: StimelaContext, images: List[str], all=False):
+def push(images: List[str], all=False):
+    from stimela.main import BACKEND
+    from stimela import CONFIG
+    log = stimela.logger()
 
-    available_images = context.backend.available_images()
-    push_images = context.config.base.keys() if all else images
+    available_images = BACKEND.available_images()
+    push_images = CONFIG.base.keys() if all else images
 
     for imagename in push_images:
         if ':' in imagename:
@@ -24,18 +26,18 @@ def push(context: StimelaContext, images: List[str], all=False):
         else:
             version = None
 
-        if imagename not in context.config.base:
-            context.log.error(f"base image '{imagename}' is not known to Stimela")
+        if imagename not in CONFIG.base:
+            log.error(f"base image '{imagename}' is not known to Stimela")
             return 2
 
-        image = context.config.base[imagename]
+        image = CONFIG.base[imagename]
 
         if version is None:
             push_versions = image.images.keys()
         elif version in image.images:
             push_versions = [version]
         else:
-            context.log.error(f"version '{version}' is not defined for base image '{imagename}'")
+            log.error(f"version '{version}' is not defined for base image '{imagename}'")
             return 2
 
         # now loop over push versions
@@ -43,9 +45,9 @@ def push(context: StimelaContext, images: List[str], all=False):
             # check if already exists
             if imagename not in available_images or version not in available_images[imagename] \
                         or available_images[imagename][version].build is None:
-                context.log.warning(f"image '{imagename}:{version}' not found, has it been built?")
+                log.warning(f"image '{imagename}:{version}' not found, has it been built?")
                 continue
 
-            context.backend.push(image, version)
+            BACKEND.push(image, version)
 
 

--- a/stimela/commands/run.py
+++ b/stimela/commands/run.py
@@ -1,7 +1,8 @@
 import click
+import stimela
 from stimela import config, GLOBALS
 from stimela.kitchen import recipe
-from stimela.main import StimelaContext, cli, pass_stimela_context
+from stimela.main import cli
 from typing import Optional, List
 
 
@@ -15,9 +16,11 @@ from typing import Optional, List
                 help="MS folder. MSs should be placed here. Also, empty MSs will be placed here")
 @click.option("-g", "--globals", "myglobals", metavar="KEY=VALUE[:TYPE]", multiple=True,
                 help="Global variables to pass to script. The type is assumed to string unless specified")
-@pass_stimela_context
-def run(context: StimelaContext, script: str, outdir: str=None, 
+def run(script: str, outdir: str=None, 
         indir: str=None, msdir: str=None, myglobals: List[str]=[]):
+    from stimela.main import BACKEND
+    from stimela import CONFIG
+    log = stimela.logger()
     
     global GLOBALS
     _globals = dict(_STIMELA_INPUT=indir, _STIMELA_OUTPUT=outdir,

--- a/stimela/config.py
+++ b/stimela/config.py
@@ -125,6 +125,7 @@ def load_config(extra_configs=List[str]):
         lib: StimelaLibrary = StimelaLibrary()
         cabs: Dict[str, Cab] = MISSING
         opts: StimelaOptions = StimelaOptions()
+        vars: Dict[str, Any] = EmptyDictDefault()
 
     # start with empty structured config containing schema
     base_schema = OmegaConf.structured(StimelaImage) 

--- a/stimela/configuratt/__init__.py
+++ b/stimela/configuratt/__init__.py
@@ -172,3 +172,5 @@ def build_nested_config(conf, filelist: List[str], schema,
             raise RuntimeError(f"config error in {path}:\n  {exc}")
 
     return section_content
+
+

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -382,10 +382,10 @@ class Recipe(Cargo):
                         raise RecipeValidationError(f"alias '{name}' refers to unknown step '{step_label}'", log=log)
                     self._add_alias(name, step_label, step, step_param_name)
 
-            # automatically make aliases for unset required parameters 
+            # automatically make aliases for unset step parameters 
             for label, step in self.steps.items():
                 for name, schema in step.inputs_outputs.items():
-                    if (label, name) not in self._alias_map and name not in step.params and schema.required:
+                    if (label, name) not in self._alias_map and name not in step.params: # and schema.required:
                         auto_name = f"{label}_{name}"
                         if auto_name in self.inputs or auto_name in self.outputs:
                             raise RecipeValidationError(f"auto-generated parameter name '{auto_name}' conflicts with another name. Please define an explicit alias for this.", log=log)

--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -148,7 +148,7 @@ def setup_file_logger(log: logging.Logger, logfile: str, level: Optional[Union[i
     
     # does the logger need a new FileHandler created
     if current_logfile != logfile:
-        log.info(f"starting new logfile {logfile} (previous was {current_logfile})")
+        log.debug(f"starting new logfile {logfile} (previous was {current_logfile})")
 
         # remove old FH if so
         if fh is not None:

--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -1,0 +1,215 @@
+import sys, os.path, re
+import logging
+from typing import Optional, Dict, Any, Union
+
+class MultiplexingHandler(logging.Handler):
+    """handler to send INFO and below to stdout, everything above to stderr"""
+    def __init__(self, info_stream=sys.stdout, err_stream=sys.stderr):
+        super(MultiplexingHandler, self).__init__()
+        self.info_handler = logging.StreamHandler(info_stream)
+        self.err_handler = logging.StreamHandler(err_stream)
+        self.multiplex = True
+
+    def emit(self, record):
+        handler = self.err_handler if record.levelno > logging.INFO and self.multiplex else self.info_handler
+        handler.emit(record)
+        # ignore broken pipes, this often happens when cleaning up and exiting
+        try:
+            handler.flush()
+        except BrokenPipeError:
+            pass
+
+    def flush(self):
+        try:
+            self.err_handler.flush()
+            self.info_handler.flush()
+        except BrokenPipeError:
+            pass
+
+    def close(self):
+        self.err_handler.close()
+        self.info_handler.close()
+
+    def setFormatter(self, fmt):
+        self.err_handler.setFormatter(fmt)
+        self.info_handler.setFormatter(fmt)
+
+class ConsoleColors():
+    WARNING = '\033[93m' if sys.stdin.isatty() else ''
+    ERROR   = '\033[91m' if sys.stdin.isatty() else ''
+    BOLD    = '\033[1m'  if sys.stdin.isatty() else ''
+    DIM     = '\033[2m'  if sys.stdin.isatty() else ''
+    GREEN   = '\033[92m' if sys.stdin.isatty() else ''
+    ENDC    = '\033[0m'  if sys.stdin.isatty() else ''
+
+    BEGIN = "<COLORIZE>"
+    END   = "</COLORIZE>"
+
+    @staticmethod
+    def colorize(msg, *styles):
+        style = "".join(styles)
+        return msg.replace(ConsoleColors.BEGIN, style).replace(ConsoleColors.END, ConsoleColors.ENDC if style else "")
+
+class ColorizingFormatter(logging.Formatter):
+    """This Formatter inserts color codes into the string according to severity"""
+    def __init__(self, fmt=None, datefmt=None, style="%", default_color=None):
+        super(ColorizingFormatter, self).__init__(fmt, datefmt, style)
+        self._default_color = default_color or ""
+
+    def format(self, record):
+        style = ConsoleColors.BOLD if hasattr(record, 'boldface') else ""
+        if hasattr(record, 'color'):
+            style += getattr(ConsoleColors, record.color or "None", "")
+        elif record.levelno >= logging.ERROR:
+            style += ConsoleColors.ERROR
+        elif record.levelno >= logging.WARNING:
+            style += ConsoleColors.WARNING
+        return ConsoleColors.colorize(super(ColorizingFormatter, self).format(record), style or self._default_color)
+
+
+class SelectiveFormatter(logging.Formatter):
+    """Selective formatter. if condition(record) is True, invokes other formatter"""
+    def __init__(self, default_formatter, dispatch_list):
+        self._dispatch_list = dispatch_list
+        self._default_formatter = default_formatter
+
+    def format(self, record):
+        for condition, formatter in self._dispatch_list:
+            if condition(record):
+                return formatter.format(record)
+        else:
+            return self._default_formatter.format(record)
+
+
+_logger = None
+log_console_handler = log_formatter = log_boring_formatter = log_colourful_formatter = None
+
+
+def is_logger_initialized():
+    return _logger is not None
+
+
+def logger(name="STIMELA", propagate=False, console=True, boring=False,
+           fmt="{asctime} {name} {levelname}: {message}",
+           col_fmt="{asctime} {name} %s{levelname}: {message}%s"%(ConsoleColors.BEGIN, ConsoleColors.END),
+           sub_fmt="# {message}",
+           col_sub_fmt="%s# {message}%s"%(ConsoleColors.BEGIN, ConsoleColors.END),
+           datefmt="%Y-%m-%d %H:%M:%S", loglevel="INFO"):
+    """Returns the global Stimela logger (initializing if not already done so, with the given values)"""
+    global _logger
+    if _logger is None:
+        _logger = logging.getLogger(name)
+        if type(loglevel) is str:
+            loglevel = getattr(logging, loglevel)
+        _logger.setLevel(loglevel)
+        _logger.propagate = propagate
+
+        global log_console_handler, log_formatter, log_boring_formatter, log_colourful_formatter
+
+        # this function checks if the log record corresponds to stdout/stderr output from a cab
+        def _is_from_subprocess(rec):
+            return hasattr(rec, 'stimela_subprocess_output')
+
+        log_boring_formatter = SelectiveFormatter(
+                    logging.Formatter(fmt, datefmt, style="{"),
+                    [(_is_from_subprocess, logging.Formatter(sub_fmt, datefmt, style="{"))])
+
+        log_colourful_formatter = SelectiveFormatter(
+                    ColorizingFormatter(col_fmt, datefmt, style="{"),
+                    [(_is_from_subprocess, ColorizingFormatter(fmt=col_sub_fmt, datefmt=datefmt, style="{",
+                                                               default_color=ConsoleColors.DIM))])
+
+        log_formatter = log_boring_formatter if boring else log_colourful_formatter
+
+        if console:
+            if "SILENT_STDERR" in os.environ and os.environ["SILENT_STDERR"].upper()=="ON":
+                log_console_handler = logging.StreamHandler(stream=sys.stdout)
+            else:  
+                log_console_handler = MultiplexingHandler()
+            log_console_handler.setFormatter(log_formatter)
+            log_console_handler.setLevel(loglevel)
+            _logger.addHandler(log_console_handler)
+
+        import scabha
+        scabha.set_logger(_logger)
+
+    return _logger
+
+
+_logger_file_handlers = {}
+
+
+def has_file_logger(log: logging.Logger):
+    return log.name in _logger_file_handlers
+
+
+def setup_file_logger(log: logging.Logger, logfile: str, level: Optional[Union[int, str]] = logging.INFO):
+    current_logfile, fh = _logger_file_handlers.get(log.name, (None, None))
+    
+    # does the logger need a new FileHandler created
+    if current_logfile != logfile:
+        log.info(f"starting new logfile {logfile} (previous was {current_logfile})")
+
+        # remove old FH if so
+        if fh is not None:
+            fh.close()
+            log.removeHandler(fh)
+
+        # create new one
+        logdir = os.path.dirname(logfile)
+        if logdir and not os.path.exists(logdir):            
+            os.makedirs(logdir)
+        
+        fh = logging.FileHandler(logfile, 'w', delay=True)
+        fh.setFormatter(log_boring_formatter)
+        log.addHandler(fh)
+
+        _logger_file_handlers[log.name] = logfile, fh
+
+    # resolve level
+    if level is not None:
+        if type(level) is str:
+            level = getattr(logging, level, logging.INFO)
+        fh.setLevel(level)
+
+    return log
+
+
+def make_filename_substitutions(template: str, subst: Dict[str, Any], default_subst: Optional[Dict[str, Any]]=None):
+    # make substitution dict    
+    import stimela.config
+    default_subst = default_subst or stimela.config.SUBSTITUTIONS
+    if subst:
+        default_subst = default_subst.copy()
+        default_subst.update(**subst)
+
+    return re.sub(r'[^a-zA-Z0-9_./-]', '_', template.format(**default_subst))
+
+
+def get_logfile_path(template: str, subst: Dict[str, Any]):
+    import stimela
+    log = logger()
+
+    dirname = os.path.dirname(template) or stimela.CONFIG.opts.log.dir or "."
+    basename = f"{stimela.CONFIG.opts.log.prefix}{os.path.basename(template)}{stimela.CONFIG.opts.log.suffix}"
+    path = os.path.join(dirname, basename)
+    
+    # substitute
+    try: 
+        path = make_filename_substitutions(path, subst)
+    except Exception as exc:
+        log.error(f"bad substitution in logfile path '{path}': {exc}")
+        return None
+    
+    return path
+
+
+def update_file_logger(log: logging.Logger, template: str, subst: Dict[str, Any]):
+    import stimela
+
+    log_filename = get_logfile_path(template, subst)
+    if log_filename is not None:
+        setup_file_logger(log, log_filename, stimela.CONFIG.opts.log.level)
+
+
+

--- a/stimela/tests/test_cubical_recipe.yml
+++ b/stimela/tests/test_cubical_recipe.yml
@@ -20,6 +20,10 @@ cabs:
     image: null
     command: echo # just a dummy for now 
 
+opts:
+  log:
+    nest: 2
+
 recipe:
   name: "cubical-loop"
   for_loop:

--- a/stimela/tests/test_loop_recipe.yml
+++ b/stimela/tests/test_loop_recipe.yml
@@ -1,3 +1,5 @@
+
+## recipes may define or redefine or augment cabs
 cabs:
   cubical:
     command: echo # just a dummy for now 
@@ -18,6 +20,7 @@ cabs:
         writeable: true
         alias: data-ms
 
+## lib.recipes.* may be added to and invoked via _use
 lib:
   recipes:
     cubical_image:
@@ -33,7 +36,46 @@ lib:
         image:
             cab: myclean
 
+    test-loop-recipe:
+      name: "test loop"
+      for_loop:
+        var: ms
+        over: ms_list
+      aliases:
+        ms: ['cubical_image.ms']
+      inputs:
+        ms_list:
+          dtype: List[str]
+          required: true
+      defaults:
+        ms_list: [a,b,c]
+      steps:
+        cubical_image:
+          recipe:
+            _use: lib.recipes.cubical_image
 
+opts:
+  log:
+    dir: logs-{datetime} 
+    nest: 3
+
+
+## but also top-level sections are treated as recipe names
+cubical_image:
+  name: "cubical_image"
+  info: 'does one step of cubical, followed by one step of imaging'
+  dirs:
+    log: logs
+  aliases:
+    ms: [calibrate.ms, image.ms]
+  steps: 
+    calibrate: 
+        cab: cubical
+    image:
+        cab: myclean
+
+## ....and can be invoked via _use, see below
+## The current default recipe to run is called "recipe", but use exec -r to override
 recipe:
   name: "test loop"
   for_loop:
@@ -47,7 +89,8 @@ recipe:
       required: true
   defaults:
     ms_list: [a,b,c]
+  logname: "{name}.MS{params.ms}"
   steps:
     cubical_image:
       recipe:
-        _use: lib.recipes.cubical_image
+        _use: cubical_image


### PR DESCRIPTION
Cleaned up and refactored the logging. See ``test_loop_recipe.yml`` for an example. In a nutshell, this part of the recipe (or indeed any stimela config file):

```yml
opts:
  log:
    dir: logs-{datetime} 
    nest: 3
```

...tells it to use a specific directory for logfiles (logs-YYYYMMDD-hhmmss), and to nest the logs three levels deep -- i.e., nested recipe steps up to a depth of 3 will have their own logsfiles split out (our old behaviour was always nest=1, i.e. a log for the recipe and a log for each step).

And then there's the custom ``logname`` feature within a recipe:

```yml
recipe:
  name: "test loop"
  for_loop:
    var: ms
    over: ms_list
  ...
  logname: "{name}.MS{params.ms}"
```

makes the logfile name depend on the ``ms`` parameter, over which the recipe loops -- so each iteration gets its own set of logs. The default ``logname`` doesn't substitute any parameters, of course, so you'd have all iterations go into the same log. 